### PR TITLE
Permutive RTD Provider: SDK-Driven Configuration

### DIFF
--- a/integrationExamples/gpt/permutiveRtdProvider_example.html
+++ b/integrationExamples/gpt/permutiveRtdProvider_example.html
@@ -10,13 +10,21 @@
 
             function setLocalStorageData () {
               const data = {
+                // AC Signals
+                _psegs: ['1234', '1000001', '1000002'], // Standard cohorts (>= 1000000)
+                _pcrprs: ['pcrprs1', 'pcrprs2'], // DCR cohorts
+
+                // SSP Signals
+                _pssps: { ssps: ['appnexus', 'some other'], cohorts: ['abcd', 'efgh', 'ijkl'] },
+
+                // CC Signals - New unified custom cohorts model
+                _pprebid: ['custom1', 'custom2', 'custom3'], // Primary custom cohorts
+
+                // CC Signals - Legacy keys (merged with _pprebid)
                 _pdfps: ['gam1', 'gam2'],
                 _prubicons: ['rubicon1', 'rubicon2'],
                 _papns: ['appnexus1', 'appnexus2'],
-                _psegs: ['1234', '1000001', '1000002'],
-                _ppam: ['ppam1', 'ppam2'],
-                _pcrprs: ['pcrprs1', 'pcrprs2'],
-                _pssps: { ssps: ['appnexus', 'some other'], cohorts: ['abcd', 'efgh', 'ijkl'] },
+                _pindexs: ['index1', 'index2'],
               }
 
               for (let key in data) {
@@ -91,15 +99,6 @@
                       ],
                       ozoneData: {}
                     }
-                  },
-                  {
-                    bidder: 'trustx',
-                    params: {
-                      uid: 45,
-                      keywords: {
-                        test_kv: ['true']
-                      }
-                    }
                   }
                 ]
               },
@@ -150,7 +149,8 @@
                       name: 'permutive',
                       waitForIt: true,
                       params: {
-                        acBidders: ['appnexus', 'rubicon', 'ozone', 'trustx', 'ix'],
+                        acBidders: ['appnexus', 'rubicon', 'ozone', 'ix'],
+                        ccBidders: ['ozone'], // Custom cohort bidders (ix, rubicon, appnexus, gam get them automatically)
                         maxSegs: 500,
                         transformations: [
                           {
@@ -179,6 +179,7 @@
                   ]
                 }
               });
+
               pbjs.setBidderConfig({
                 bidders: ['appnexus', 'rubicon', 'ix'],
                 config: {

--- a/integrationExamples/gpt/permutiveRtdProvider_example.html
+++ b/integrationExamples/gpt/permutiveRtdProvider_example.html
@@ -17,14 +17,24 @@
                 // SSP Signals
                 _pssps: { ssps: ['appnexus', 'some other'], cohorts: ['abcd', 'efgh', 'ijkl'] },
 
-                // CC Signals - New unified custom cohorts model
-                _pprebid: ['custom1', 'custom2', 'custom3'], // Primary custom cohorts
-
-                // CC Signals - Legacy keys (merged with _pprebid)
+                // CC Signals - Legacy keys (only sent to ix, rubicon, appnexus, gam by default)
                 _pdfps: ['gam1', 'gam2'],
                 _prubicons: ['rubicon1', 'rubicon2'],
                 _papns: ['appnexus1', 'appnexus2'],
                 _pindexs: ['index1', 'index2'],
+
+                // SDK-Driven Configuration
+                // Recommended approach: allows dynamic cohort distribution without Prebid config changes
+                _ppbconf: [
+                  {
+                    bidders: ['ozone'],
+                    cohorts: ['sdk_cohort_1', 'sdk_cohort_2'],
+                    locations: [
+                      { path: 'user.data', name: 'permutive' },
+                      { path: 'user.keywords', key: 'permutive' }
+                    ]
+                  }
+                ]
               }
 
               for (let key in data) {
@@ -150,7 +160,6 @@
                       waitForIt: true,
                       params: {
                         acBidders: ['appnexus', 'rubicon', 'ozone', 'ix'],
-                        ccBidders: ['ozone'], // Custom cohort bidders (ix, rubicon, appnexus, gam get them automatically)
                         maxSegs: 500,
                         transformations: [
                           {

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -323,10 +323,9 @@ export function getSegments(maxSegs) {
               .filter((seg) => seg >= 1000000)
               .map(String),
           ) || [];
-        const _ppam = makeSafe(() => readSegments('_ppam', []).map(String)) || [];
         const _pcrprs = makeSafe(() => readSegments('_pcrprs', []).map(String)) || [];
 
-        return [..._pcrprs, ..._ppam, ...legacySegs];
+        return [..._pcrprs, ...legacySegs];
       }) || [],
 
     ix:

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -118,8 +118,8 @@ export function getModuleConfig(customModuleConfig) {
 }
 
 /**
- * Sets ortb2 config for ac bidders
- * @param {Object} bidderOrtb2 - The ortb2 object for the all bidders
+ * Sets ortb2 config for bidders with Permutive signals
+ * @param {Object} bidderOrtb2 - The ortb2 object for all bidders
  * @param {Object} moduleConfig - Publisher config for module
  * @param {Object} segmentData - Segment data grouped by bidder or type
  */
@@ -132,7 +132,7 @@ export function setBidderRtb (bidderOrtb2, moduleConfig, segmentData) {
   const sspBidders = segmentData?.ssp?.ssps ?? []
   const sspSignals = segmentData?.ssp?.cohorts ?? []
   const topics = segmentData?.topics ?? {}
-  const customCohorts = segmentData?.customCohorts ?? []
+  const ccSignals = segmentData?.customCohorts ?? []
 
   const ccBidders = deepAccess(moduleConfig, 'params.ccBidders') || []
   const legacyCcBidders = ['ix', 'rubicon', 'appnexus', 'gam']
@@ -151,7 +151,7 @@ export function setBidderRtb (bidderOrtb2, moduleConfig, segmentData) {
       currConfig,
       isAcBidder ? acSignals : [],
       isSspBidder ? sspSignals : [],
-      isCcBidder ? customCohorts : [],
+      isCcBidder ? ccSignals : [],
       topics,
       transformationConfigs,
       maxSegs

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -30,10 +30,9 @@
 
 import {getGlobal} from '../src/prebidGlobal.js';
 import {submodule} from '../src/hook.js';
+import {MODULE_TYPE_RTD} from '../src/activities/modules.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {deepAccess, deepSetValue, isFn, logError, mergeDeep, isPlainObject, safeJSONParse, prefixLog} from '../src/utils.js';
-
-import {MODULE_TYPE_RTD} from '../src/activities/modules.js';
 
 /**
  * @typedef {import('../modules/rtdModule/index.js').RtdSubmodule} RtdSubmodule
@@ -427,9 +426,9 @@ function readSegments (key, defaultValue) {
 const unknownIabSegmentId = '_unknown_'
 
 /**
- * Functions to apply to ORT2B2 `user.data` objects.
- * Each function should return an a new object containing a `name`, (optional) `ext` and `segment`
- * properties. The result of the each transformation defined here will be appended to the array
+ * Functions to apply to ORTB2 `user.data` objects.
+ * Each function should return a new object containing `name`, (optional) `ext` and `segment`
+ * properties. The result of each transformation defined here will be appended to the array
  * under `user.data` in the bid request.
  */
 const ortb2UserDataTransformations = {
@@ -454,9 +453,8 @@ function iabSegmentId(permutiveSegmentId, iabIds) {
 
 /**
  * Pull the latest configuration and cohort information and update accordingly.
- *
- * @param reqBidsConfigObj - Bidder provided config for request
- * @param moduleConfig - Publisher provided config
+ * @param {Object} reqBidsConfigObj - Bidder provided config for request
+ * @param {Object} moduleConfig - Publisher provided config
  */
 export function readAndSetCohorts(reqBidsConfigObj, moduleConfig) {
   const segmentData = getSegments(deepAccess(moduleConfig, 'params.maxSegs'))

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -6,28 +6,6 @@
  * @requires module:modules/realTimeData
  */
 
-/**
- * LOCAL STORAGE KEYS:
- * - _psegs: Raw Permutive segments (filtered to >= 1000000 for Standard Cohorts)
- * - _pcrprs: Data Clean Room (DCR) cohorts
- * - _pssps: { ssps: [...], cohorts: [...] } - SSP signals and bidder codes
- * - _pprebid: Custom cohorts
- * - _papns, _prubicons, _pindexs, _pdfps: Legacy custom cohorts (merged with _pprebid)
- * - _ppsts: Privacy Sandbox Topics by taxonomy version
- *
- * SIGNAL TYPES:
- * - AC Signals: Standard Cohorts + DCR Cohorts → AC bidders (params.acBidders)
- * - SSP Signals: Curation signals → SSP bidders (from _pssps.ssps)
- * - CC Signals: Custom cohorts → CC bidders (params.ccBidders) + legacy bidders (ix, rubicon, appnexus, gam)
- * - Topics: Privacy Sandbox Topics → All bidders
- *
- * ORTB2 LOCATIONS:
- * - ortb2.user.data "permutive.com": AC/SSP Signals
- * - ortb2.user.data "permutive": CC Signals
- * - ortb2.user.keywords: p_standard, p_standard_aud, permutive
- * - ortb2.user.ext.data: p_standard, permutive
- */
-
 import {getGlobal} from '../src/prebidGlobal.js';
 import {submodule} from '../src/hook.js';
 import {MODULE_TYPE_RTD} from '../src/activities/modules.js';
@@ -38,298 +16,120 @@ import {deepAccess, deepSetValue, isFn, logError, mergeDeep, isPlainObject, safe
  * @typedef {import('../modules/rtdModule/index.js').RtdSubmodule} RtdSubmodule
  */
 
+// ============================================================================
+// MODULE CONSTANTS AND STORAGE
+// ============================================================================
+
 const MODULE_NAME = 'permutive'
 
 const logger = prefixLog('[PermutiveRTD]')
 
 export const PERMUTIVE_SUBMODULE_CONFIG_KEY = 'permutive-prebid-rtd'
+export const SDK_CONFIG_KEY = '_ppbconf'
 export const PERMUTIVE_STANDARD_KEYWORD = 'p_standard'
 export const PERMUTIVE_CUSTOM_COHORTS_KEYWORD = 'permutive'
 export const PERMUTIVE_STANDARD_AUD_KEYWORD = 'p_standard_aud'
 
 export const storage = getStorageManager({moduleType: MODULE_TYPE_RTD, moduleName: MODULE_NAME})
 
+let cachedPermutiveModuleConfig = {}
+let permutiveSDKInRealTime = false
+
+// ============================================================================
+// PUBLIC API - ENTRY POINTS
+// ============================================================================
+
+/**
+ * Initialize the Permutive RTD module
+ * @param {Object} moduleConfig - Module configuration
+ * @param {Object} userConsent - User consent object
+ * @return {boolean} Always returns true
+ */
 function init(moduleConfig, userConsent) {
   readPermutiveModuleConfigFromCache()
-
   return true
 }
 
-function liftIntoParams(params) {
-  return isPlainObject(params) ? { params } : {}
-}
-
-let cachedPermutiveModuleConfig = {}
-
 /**
- * Access the submodules RTD params that are cached to LocalStorage by the Permutive SDK. This lets the RTD submodule
- * apply publisher defined params set in the Permutive platform, so they may still be applied if the Permutive SDK has
- * not initialised before this submodule is initialised.
+ * Pull the latest configuration and cohort information and update accordingly.
+ * This is the main entry point called by the RTD module.
+ * @param {Object} reqBidsConfigObj - Bidder provided config for request
+ * @param {Object} moduleConfig - Publisher provided config
  */
-function readPermutiveModuleConfigFromCache() {
-  const params = safeJSONParse(storage.getDataFromLocalStorage(PERMUTIVE_SUBMODULE_CONFIG_KEY))
-  cachedPermutiveModuleConfig = liftIntoParams(params)
-  return cachedPermutiveModuleConfig
+export function readAndSetCohorts(reqBidsConfigObj, moduleConfig) {
+  const segmentData = getSegments(deepAccess(moduleConfig, 'params.maxSegs'))
+
+  makeSafe(function () {
+    // Legacy route with custom parameters
+    // ACK policy violation, in process of removing
+    setSegments(reqBidsConfigObj, moduleConfig, segmentData)
+  });
+
+  makeSafe(function () {
+    // Route for bidders supporting ORTB2
+    setBidderRtb(reqBidsConfigObj.ortb2Fragments?.bidder, moduleConfig, segmentData)
+  })
 }
 
-/**
- * Access the submodules RTD params attached to the Permutive SDK.
- *
- * @return The Permutive config available by the Permutive SDK or null if the operation errors.
- */
-function getParamsFromPermutive() {
-  try {
-    return liftIntoParams(window.permutive.addons.prebid.getPermutiveRtdConfig())
-  } catch (e) {
-    return null
-  }
-}
-
-/**
- * Merges segments into existing bidder config in reverse priority order. The highest priority is 1.
- *
- *   1. customModuleConfig <- set by publisher with pbjs.setConfig
- *   2. permutiveRtdConfig <- set by the publisher using the Permutive platform
- *   3. defaultConfig
- *
- * As items with a higher priority will be deeply merged into the previous config, deep merges are performed by
- * reversing the priority order.
- *
- * @param {Object} customModuleConfig - Publisher config for module
- * @return {Object} Deep merges of the default, Permutive and custom config.
- */
-export function getModuleConfig(customModuleConfig) {
-  // Use the params from Permutive if available, otherwise fallback to the cached value set by Permutive.
-  const permutiveModuleConfig = getParamsFromPermutive() || cachedPermutiveModuleConfig
-
-  return mergeDeep({
-    waitForIt: false,
-    params: {
-      maxSegs: 500,
-      acBidders: [],
-      ccBidders: [],
-      overwrites: {},
-    },
-  },
-  permutiveModuleConfig,
-  customModuleConfig,
-  )
-}
+// ============================================================================
+// HIGH-LEVEL ORCHESTRATION
+// ============================================================================
 
 /**
  * Sets ortb2 config for bidders with Permutive signals
+ *
+ * This is the main function that orchestrates the dual-mode implementation:
+ * 1. Populates cohorts from SDK-driven config (_ppbconf)
+ * 2. Populates cohorts from legacy config (localStorage keys)
+ * 3. Merges and deduplicates cohorts
+ * 4. Applies to ORTB2 structure
+ *
  * @param {Object} bidderOrtb2 - The ortb2 object for all bidders
  * @param {Object} moduleConfig - Publisher config for module
  * @param {Object} segmentData - Segment data grouped by bidder or type
  */
 export function setBidderRtb (bidderOrtb2, moduleConfig, segmentData) {
-  const acBidders = deepAccess(moduleConfig, 'params.acBidders')
   const maxSegs = deepAccess(moduleConfig, 'params.maxSegs')
   const transformationConfigs = deepAccess(moduleConfig, 'params.transformations') || []
-
-  const acSignals = segmentData?.ac ?? []
-  const sspBidders = segmentData?.ssp?.ssps ?? []
-  const sspSignals = segmentData?.ssp?.cohorts ?? []
-  const topics = segmentData?.topics ?? {}
-  const ccSignals = segmentData?.customCohorts ?? []
-
-  const ccBidders = deepAccess(moduleConfig, 'params.ccBidders') || []
-  const legacyCcBidders = ['ix', 'rubicon', 'appnexus', 'gam']
-
-  const bidders = new Set([...acBidders, ...sspBidders, ...ccBidders, ...legacyCcBidders])
-
-  bidders.forEach(function (bidder) {
-    const currConfig = { ortb2: bidderOrtb2[bidder] || {} }
-
-    const isAcBidder = acBidders.indexOf(bidder) > -1
-    const isSspBidder = sspBidders.indexOf(bidder) > -1
-    const isCcBidder = ccBidders.indexOf(bidder) > -1 || legacyCcBidders.indexOf(bidder) > -1
-
-    const nextConfig = updateOrtbConfig(
-      bidder,
-      currConfig,
-      isAcBidder ? acSignals : [],
-      isSspBidder ? sspSignals : [],
-      isCcBidder ? ccSignals : [],
-      topics,
-      transformationConfigs,
-      maxSegs
-    )
-    bidderOrtb2[bidder] = nextConfig.ortb2
-  })
-}
-
-/**
- * Updates ORTB2 config for a bidder with Permutive signals
- * @param {string} bidder
- * @param {Object} currConfig
- * @param {string[]} acSignals - AC Signals for this bidder
- * @param {string[]} sspSignals - SSP Signals for this bidder
- * @param {string[]} ccSignals - CC Signals for this bidder
- * @param {Object} topics - Privacy Sandbox Topics
- * @param {Object[]} transformationConfigs - IAB taxonomy transformations
- * @param {number} maxSegs - Maximum segments per signal type
- * @return {Object} Updated ortb2 config
- */
-function updateOrtbConfig(bidder, currConfig, acSignals, sspSignals, ccSignals, topics, transformationConfigs, maxSegs) {
-  logger.logInfo(`Current ortb2 config`, { bidder, config: currConfig })
-
-  // Merge AC + SSP signals for p_standard and permutive.com provider
-  const mergedSignals = [...new Set([...acSignals, ...sspSignals])].slice(0, maxSegs)
-
-  const name = 'permutive.com'
-
-  const permutiveUserData = {
-    name,
-    segment: mergedSignals.map(segmentId => ({ id: segmentId })),
-  }
-
-  const transformedUserData = transformationConfigs
-    .filter(({ id }) => ortb2UserDataTransformations.hasOwnProperty(id))
-    .map(({ id, config }) => ortb2UserDataTransformations[id](permutiveUserData, config))
-
-  const ccUserData = {
-    name: PERMUTIVE_CUSTOM_COHORTS_KEYWORD,
-    segment: ccSignals.map(cohortID => ({ id: cohortID })),
-  }
-
-  const topicsUserData = []
-  for (const [k, value] of Object.entries(topics)) {
-    topicsUserData.push({
-      name,
-      ext: {
-        segtax: Number(k)
-      },
-      segment: value.map(topic => ({ id: topic.toString() })),
-    })
-  }
-
-  const ortbConfig = mergeDeep({}, currConfig)
-  const currentUserData = deepAccess(ortbConfig, 'ortb2.user.data') || []
-  const updatedUserData = currentUserData
-    .filter(el => el.name !== permutiveUserData.name && el.name !== ccUserData.name)
-    .concat(permutiveUserData, transformedUserData, ccUserData)
-    .concat(topicsUserData)
-
-  logger.logInfo(`Updating ortb2.user.data`, { bidder, user_data: updatedUserData })
-  deepSetValue(ortbConfig, 'ortb2.user.data', updatedUserData)
-
-  const currentKeywords = deepAccess(ortbConfig, 'ortb2.user.keywords')
-  const keywordGroups = {
-    [PERMUTIVE_STANDARD_KEYWORD]: mergedSignals,
-    [PERMUTIVE_STANDARD_AUD_KEYWORD]: sspSignals,
-    [PERMUTIVE_CUSTOM_COHORTS_KEYWORD]: ccSignals,
-  }
-
-  const transformedKeywordGroups = Object.entries(keywordGroups)
-    .flatMap(([keyword, ids]) => ids.map(id => `${keyword}=${id}`))
-
-  const keywords = Array.from(new Set([
-    ...(currentKeywords || '').split(',').map(kv => kv.trim()),
-    ...transformedKeywordGroups
-  ]))
-    .filter(Boolean)
-    .join(',')
-
-  logger.logInfo(`Updating ortb2.user.keywords`, {
-    bidder,
-    keywords,
-  })
-  deepSetValue(ortbConfig, 'ortb2.user.keywords', keywords)
-
-  if (mergedSignals.length > 0) {
-    deepSetValue(ortbConfig, `ortb2.user.ext.data.${PERMUTIVE_STANDARD_KEYWORD}`, mergedSignals)
-    logger.logInfo(`Extending ortb2.user.ext.data with "${PERMUTIVE_STANDARD_KEYWORD}"`, mergedSignals)
-  }
-
-  if (ccSignals.length > 0) {
-    deepSetValue(ortbConfig, `ortb2.user.ext.data.${PERMUTIVE_CUSTOM_COHORTS_KEYWORD}`, ccSignals.map(String))
-    logger.logInfo(`Extending ortb2.user.ext.data with "${PERMUTIVE_CUSTOM_COHORTS_KEYWORD}"`, ccSignals)
-  }
-
-  if (mergedSignals.length > 0) {
-    deepSetValue(ortbConfig, `ortb2.site.ext.permutive.${PERMUTIVE_STANDARD_KEYWORD}`, mergedSignals)
-    logger.logInfo(`Extending ortb2.site.ext.permutive with "${PERMUTIVE_STANDARD_KEYWORD}"`, mergedSignals)
-  }
-
-  logger.logInfo(`Updated ortb2 config`, { bidder, config: ortbConfig })
-  return ortbConfig
-}
-
-/**
- * Set segments on bid request object
- * @param {Object} reqBidsConfigObj - Bid request object
- * @param {Object} moduleConfig - Module configuration
- * @param {Object} segmentData - Segment object
- */
-function setSegments (reqBidsConfigObj, moduleConfig, segmentData) {
-  const adUnits = (reqBidsConfigObj && reqBidsConfigObj.adUnits) || getGlobal().adUnits
-  const utils = { deepSetValue, deepAccess, isFn, mergeDeep }
-  const aliasMap = {
-    appnexusAst: 'appnexus'
-  }
-
-  if (!adUnits) {
-    return
-  }
-
-  adUnits.forEach(adUnit => {
-    adUnit.bids.forEach(bid => {
-      let { bidder } = bid
-      if (typeof aliasMap[bidder] !== 'undefined') {
-        bidder = aliasMap[bidder]
-      }
-      const acEnabled = isAcEnabled(moduleConfig, bidder)
-      const customFn = getCustomBidderFn(moduleConfig, bidder)
-
-      if (customFn) {
-        // For backwards compatibility we pass an identity function to any custom bidder function set by a publisher
-        const bidIdentity = (bid) => bid
-        customFn(bid, segmentData, acEnabled, utils, bidIdentity)
-      }
-    })
-  })
-}
-
-/**
- * Catch and log errors
- * @param {function} fn - Function to safely evaluate
- */
-function makeSafe (fn) {
-  try {
-    return fn()
-  } catch (e) {
-    logError(e)
-  }
-}
-
-function getCustomBidderFn (moduleConfig, bidder) {
-  const overwriteFn = deepAccess(moduleConfig, `params.overwrites.${bidder}`)
-
-  if (overwriteFn && isFn(overwriteFn)) {
-    return overwriteFn
-  } else {
-    return null
-  }
-}
-
-/**
- * Check whether ac is enabled for bidder
- * @param {Object} moduleConfig - Module configuration
- * @param {string} bidder - Bidder name
- * @return {boolean}
- */
-export function isAcEnabled (moduleConfig, bidder) {
   const acBidders = deepAccess(moduleConfig, 'params.acBidders') || []
-  return acBidders.includes(bidder)
-}
 
-/**
- * Check whether Permutive is on page
- * @return {boolean}
- */
-export function isPermutiveOnPage () {
-  return typeof window.permutive !== 'undefined' && typeof window.permutive.ready === 'function'
+  // Initialize merged data structures
+  const cohortMap = {}
+  const metadataMap = {}
+
+  // Populate from both sources (SDK-driven and legacy)
+  populateFromSdkConfig(cohortMap, metadataMap)
+  populateFromLegacyConfig(cohortMap, metadataMap, moduleConfig, segmentData)
+
+  // Ensure all acBidders have ortb2 entries (even if empty)
+  // This ensures ortb2 structure is created for all configured bidders
+  acBidders.forEach(bidder => {
+    if (!cohortMap[bidder]) {
+      cohortMap[bidder] = {}
+    }
+  })
+
+  // Log what we found
+  const sdkConfigCount = readSdkConfig().length
+  const hasLegacyConfig = segmentData && (
+    (segmentData.ac && segmentData.ac.length > 0) ||
+    (segmentData.ssp && segmentData.ssp.cohorts && segmentData.ssp.cohorts.length > 0) ||
+    (segmentData.appnexus && segmentData.appnexus.length > 0) ||
+    (segmentData.rubicon && segmentData.rubicon.length > 0) ||
+    (segmentData.ix && segmentData.ix.length > 0) ||
+    (segmentData.gam && segmentData.gam.length > 0)
+  )
+
+  if (sdkConfigCount > 0 || hasLegacyConfig) {
+    logger.logInfo('Cohort sources', {
+      sdkConfigEntries: sdkConfigCount,
+      legacyConfigActive: hasLegacyConfig,
+      totalBidders: Object.keys(cohortMap).length
+    })
+  }
+
+  // Apply merged cohorts to ORTB2
+  applyMergedCohortsToOrtb2(bidderOrtb2, cohortMap, metadataMap, maxSegs, transformationConfigs)
 }
 
 /**
@@ -355,25 +155,29 @@ export function getSegments(maxSegs) {
         return [...dcrCohorts, ...standardCohorts].slice(0, maxSegs);
       }) || [],
 
-    // CC Signals
-    customCohorts:
+    // CC Signals (legacy bidder-specific)
+    appnexus:
       makeSafe(() => {
-        const pprebid = makeSafe(() =>
-          readSegments('_pprebid', []).map(String)
-        ) || [];
+        const _papns = readSegments('_papns', []);
+        return _papns.map(String).slice(0, maxSegs);
+      }) || [],
 
-        const legacyAppnexus = makeSafe(() => readSegments('_papns', []).map(String)) || [];
-        const legacyRubicon = makeSafe(() => readSegments('_prubicons', []).map(String)) || [];
-        const legacyIndex = makeSafe(() => readSegments('_pindexs', []).map(String)) || [];
-        const legacyGam = makeSafe(() => readSegments('_pdfps', []).map(String)) || [];
+    rubicon:
+      makeSafe(() => {
+        const _prubicons = readSegments('_prubicons', []);
+        return _prubicons.map(String).slice(0, maxSegs);
+      }) || [],
 
-        return [...new Set([
-          ...pprebid,
-          ...legacyAppnexus,
-          ...legacyRubicon,
-          ...legacyIndex,
-          ...legacyGam
-        ])].slice(0, maxSegs);
+    ix:
+      makeSafe(() => {
+        const _pindexs = readSegments('_pindexs', []);
+        return _pindexs.map(String).slice(0, maxSegs);
+      }) || [],
+
+    gam:
+      makeSafe(() => {
+        const _pdfps = readSegments('_pdfps', []);
+        return _pdfps.map(String).slice(0, maxSegs);
       }) || [],
 
     // SSP Signals
@@ -408,6 +212,476 @@ export function getSegments(maxSegs) {
 }
 
 /**
+ * Merges segments into existing bidder config in reverse priority order. The highest priority is 1.
+ *
+ *   1. customModuleConfig <- set by publisher with pbjs.setConfig
+ *   2. permutiveRtdConfig <- set by the publisher using the Permutive platform
+ *   3. defaultConfig
+ *
+ * As items with a higher priority will be deeply merged into the previous config, deep merges are performed by
+ * reversing the priority order.
+ *
+ * @param {Object} customModuleConfig - Publisher config for module
+ * @return {Object} Deep merges of the default, Permutive and custom config.
+ */
+export function getModuleConfig(customModuleConfig) {
+  // Use the params from Permutive if available, otherwise fallback to the cached value set by Permutive.
+  const permutiveModuleConfig = getParamsFromPermutive() || cachedPermutiveModuleConfig
+
+  return mergeDeep({
+    waitForIt: false,
+    params: {
+      maxSegs: 500,
+      acBidders: [],
+      overwrites: {},
+    },
+  },
+  permutiveModuleConfig,
+  customModuleConfig,
+  )
+}
+
+// ============================================================================
+// CORE LOGIC - DUAL MODE IMPLEMENTATION
+// ============================================================================
+
+/**
+ * Populates cohort map from SDK-driven configuration (_ppbconf)
+ *
+ * This is the recommended approach: the Permutive SDK writes cohort distribution
+ * rules to _ppbconf, specifying which cohorts should go to which bidders and where
+ * in the ORTB2 structure they should be placed.
+ *
+ * @param {Object} cohortMap - Map of bidder -> location -> cohorts
+ * @param {Object} metadataMap - Map of bidder -> location -> metadata
+ */
+function populateFromSdkConfig(cohortMap, metadataMap) {
+  const sdkConfig = readSdkConfig()
+
+  if (sdkConfig.length === 0) {
+    return
+  }
+
+  logger.logInfo('Processing SDK config', { entries: sdkConfig.length })
+
+  sdkConfig.forEach((entry, index) => {
+    const { bidders, cohorts, locations } = entry
+
+    bidders.forEach(bidder => {
+      if (!cohortMap[bidder]) {
+        cohortMap[bidder] = {}
+      }
+      if (!metadataMap[bidder]) {
+        metadataMap[bidder] = {}
+      }
+
+      locations.forEach(location => {
+        const locationKey = buildLocationKey(location)
+
+        // Initialize Set for this location if needed
+        if (!cohortMap[bidder][locationKey]) {
+          cohortMap[bidder][locationKey] = new Set()
+        }
+
+        // Add cohorts to set (automatic deduplication)
+        cohorts.forEach(cohort => {
+          cohortMap[bidder][locationKey].add(String(cohort))
+        })
+
+        // Store metadata if present (e.g., ext.segtax for Topics)
+        if (location.ext) {
+          if (!metadataMap[bidder][locationKey]) {
+            metadataMap[bidder][locationKey] = {}
+          }
+          metadataMap[bidder][locationKey].ext = location.ext
+          metadataMap[bidder][locationKey].name = location.name
+        } else if (location.name) {
+          // Store provider name for user.data locations
+          if (!metadataMap[bidder][locationKey]) {
+            metadataMap[bidder][locationKey] = {}
+          }
+          metadataMap[bidder][locationKey].name = location.name
+        }
+      })
+    })
+  })
+}
+
+/**
+ * LEGACY CONFIGURATION
+ *
+ * Populates cohort map from legacy configuration (existing localStorage keys).
+ * This handles the original approach to cohort distribution.
+ *
+ * LOCAL STORAGE KEYS:
+ * - _psegs: Raw Permutive segments (filtered to >= 1000000 for Standard Cohorts)
+ * - _pcrprs: Data Clean Room (DCR) cohorts
+ * - _pssps: { ssps: [...], cohorts: [...] } - SSP signals and bidder codes
+ * - _papns, _prubicons, _pindexs, _pdfps: Legacy custom cohorts for specific bidders
+ * - _ppsts: Privacy Sandbox Topics by taxonomy version
+ *
+ * SIGNAL TYPES:
+ * - AC Signals: Standard Cohorts + DCR Cohorts → AC bidders (params.acBidders)
+ * - SSP Signals: Curation signals → SSP bidders (from _pssps.ssps)
+ * - CC Signals: Custom cohorts → legacy bidders only (ix, rubicon, appnexus, gam)
+ * - Topics: Privacy Sandbox Topics → All bidders
+ *
+ * ORTB2 LOCATIONS:
+ * - ortb2.user.data "permutive.com": AC/SSP Signals
+ * - ortb2.user.data "permutive": CC Signals
+ * - ortb2.user.keywords: p_standard, p_standard_aud, permutive
+ * - ortb2.user.ext.data: p_standard, permutive
+ * - ortb2.site.ext.permutive: p_standard
+ *
+ * This legacy approach is maintained for backwards compatibility. The recommended approach
+ * is SDK-Driven Configuration using the _ppbconf local storage key.
+ *
+ * @param {Object} cohortMap - Map of bidder -> location -> cohorts
+ * @param {Object} metadataMap - Map of bidder -> location -> metadata
+ * @param {Object} moduleConfig - Module configuration
+ * @param {Object} segmentData - Segment data from getSegments()
+ */
+function populateFromLegacyConfig(cohortMap, metadataMap, moduleConfig, segmentData) {
+  const acBidders = deepAccess(moduleConfig, 'params.acBidders') || []
+
+  const acSignals = segmentData?.ac ?? []
+  const sspBidders = segmentData?.ssp?.ssps ?? []
+  const sspSignals = segmentData?.ssp?.cohorts ?? []
+  const topics = segmentData?.topics ?? {}
+
+  const legacyCcBidders = ['ix', 'rubicon', 'appnexus', 'gam']
+
+  const allBidders = new Set([...acBidders, ...sspBidders, ...legacyCcBidders])
+
+  allBidders.forEach(bidder => {
+    const isAcBidder = acBidders.indexOf(bidder) > -1
+    const isSspBidder = sspBidders.indexOf(bidder) > -1
+    const isLegacyCcBidder = legacyCcBidders.indexOf(bidder) > -1
+
+    // Determine which signals this bidder should receive
+    let standardSignals = []
+    if (isAcBidder && isSspBidder) {
+      // Bidder is in both lists - merge AC + SSP
+      standardSignals = [...new Set([...acSignals, ...sspSignals])]
+    } else if (isAcBidder) {
+      // AC-only bidder
+      standardSignals = acSignals
+    } else if (isSspBidder) {
+      // SSP-only bidder
+      standardSignals = sspSignals
+    }
+
+    // Add standard signals to permutive.com provider
+    if (standardSignals.length > 0) {
+      addToLocation(cohortMap, bidder, 'user.data:permutive.com', standardSignals)
+      addToLocation(cohortMap, bidder, 'user.keywords:p_standard', standardSignals)
+      addToLocation(cohortMap, bidder, 'user.ext.data:p_standard', standardSignals)
+      addToLocation(cohortMap, bidder, 'site.ext.permutive:p_standard', standardSignals)
+
+      // Store provider name for user.data
+      if (!metadataMap[bidder]) metadataMap[bidder] = {}
+      if (!metadataMap[bidder]['user.data:permutive.com']) {
+        metadataMap[bidder]['user.data:permutive.com'] = {}
+      }
+      metadataMap[bidder]['user.data:permutive.com'].name = 'permutive.com'
+    }
+
+    // SSP signals also go to p_standard_aud
+    if (isSspBidder && sspSignals.length > 0) {
+      addToLocation(cohortMap, bidder, 'user.keywords:p_standard_aud', sspSignals)
+    }
+
+    // Legacy custom cohorts go to permutive provider (bidder-specific)
+    // Note: We always add this entry for all bidders (even when empty) to maintain compatibility
+    // with the original implementation, but only legacy bidders will have non-empty segments
+    const ccSignals = isLegacyCcBidder ? (segmentData?.[bidder] ?? []) : []
+
+    // Always add to user.data (even if empty)
+    addToLocation(cohortMap, bidder, 'user.data:permutive', ccSignals)
+
+    // Store provider name for user.data
+    if (!metadataMap[bidder]) metadataMap[bidder] = {}
+    if (!metadataMap[bidder]['user.data:permutive']) {
+      metadataMap[bidder]['user.data:permutive'] = {}
+    }
+    metadataMap[bidder]['user.data:permutive'].name = PERMUTIVE_CUSTOM_COHORTS_KEYWORD
+
+    // Add to keywords and ext.data only if there are cohorts
+    if (ccSignals.length > 0) {
+      addToLocation(cohortMap, bidder, 'user.keywords:permutive', ccSignals)
+      addToLocation(cohortMap, bidder, 'user.ext.data:permutive', ccSignals)
+    }
+
+    // Topics (for all bidders that have any signals)
+    if (isAcBidder || isSspBidder || isLegacyCcBidder) {
+      for (const [taxonomy, topicIds] of Object.entries(topics)) {
+        if (topicIds && topicIds.length > 0) {
+          // Use a unique location key for each taxonomy
+          const locationKey = `user.data:permutive.com:${taxonomy}`
+          addToLocation(cohortMap, bidder, locationKey, topicIds)
+
+          // Store segtax metadata
+          if (!metadataMap[bidder]) metadataMap[bidder] = {}
+          if (!metadataMap[bidder][locationKey]) {
+            metadataMap[bidder][locationKey] = {}
+          }
+          metadataMap[bidder][locationKey].ext = { segtax: Number(taxonomy) }
+          metadataMap[bidder][locationKey].name = 'permutive.com'
+        }
+      }
+    }
+  })
+}
+
+/**
+ * Applies merged cohorts from cohort map to ORTB2 configs
+ *
+ * Takes the unified cohort map (populated from both SDK and legacy sources)
+ * and applies cohorts to the appropriate ORTB2 locations for each bidder.
+ *
+ * @param {Object} bidderOrtb2 - Bidder ORTB2 configs
+ * @param {Object} cohortMap - Map of bidder -> location -> cohorts
+ * @param {Object} metadataMap - Map of bidder -> location -> metadata
+ * @param {number} maxSegs - Max segments to include
+ * @param {Array} transformationConfigs - Transformation configs
+ */
+function applyMergedCohortsToOrtb2(bidderOrtb2, cohortMap, metadataMap, maxSegs, transformationConfigs) {
+  Object.entries(cohortMap).forEach(([bidder, locations]) => {
+    // Create a deep copy to avoid mutating shared references
+    const ortbConfig = { ortb2: mergeDeep({}, bidderOrtb2[bidder] || {}) }
+
+    logger.logInfo('Applying cohorts for bidder', { bidder, locations: Object.keys(locations).length })
+
+    Object.entries(locations).forEach(([locationKey, cohortSet]) => {
+      // Convert Set to Array and apply maxSegs
+      const cohorts = Array.from(cohortSet).slice(0, maxSegs)
+      const metadata = metadataMap[bidder]?.[locationKey] || {}
+
+      // Parse location key
+      const parts = locationKey.split(':')
+      const path = parts[0]
+
+      if (path === 'user.data') {
+        // Extract provider name (second part)
+        const providerName = parts[1]
+        applyToUserData(ortbConfig, providerName, cohorts, metadata, transformationConfigs)
+      } else if (path === 'user.keywords') {
+        const keywordKey = parts[1]
+        applyToUserKeywords(ortbConfig, keywordKey, cohorts)
+      } else if (path === 'user.ext.data') {
+        const key = parts[1]
+        applyToUserExtData(ortbConfig, key, cohorts)
+      } else if (path === 'site.ext.permutive') {
+        const key = parts[1]
+        applyToSiteExtPermutive(ortbConfig, key, cohorts)
+      }
+    })
+
+    bidderOrtb2[bidder] = ortbConfig.ortb2
+  })
+}
+
+// ============================================================================
+// ORTB2 APPLICATION HELPERS
+// ============================================================================
+
+/**
+ * Applies cohorts to user.data location
+ * @param {Object} ortbConfig - ORTB2 config object
+ * @param {string} providerName - Provider name
+ * @param {string[]} cohorts - Cohorts to apply
+ * @param {Object} metadata - Metadata (ext, etc.)
+ * @param {Array} transformationConfigs - Transformation configs (for legacy only)
+ */
+function applyToUserData(ortbConfig, providerName, cohorts, metadata, transformationConfigs) {
+  // For 'permutive' provider, always add entry (even if empty) to maintain compatibility
+  // For other providers, skip if no cohorts
+  if (cohorts.length === 0 && providerName !== PERMUTIVE_CUSTOM_COHORTS_KEYWORD) return
+
+  const userData = {
+    name: providerName,
+    segment: cohorts.map(id => ({ id })),
+    ...(metadata.ext && { ext: metadata.ext })
+  }
+
+  // Apply transformations ONLY for legacy permutive.com provider (without ext.segtax)
+  const transformedUserData = (providerName === 'permutive.com' && !metadata.ext && transformationConfigs && cohorts.length > 0)
+    ? transformationConfigs
+      .filter(({ id }) => ortb2UserDataTransformations.hasOwnProperty(id))
+      .map(({ id, config }) => ortb2UserDataTransformations[id](userData, config))
+    : []
+
+  const currentUserData = deepAccess(ortbConfig, 'ortb2.user.data') || []
+
+  // Only remove entries that match both name AND ext (to allow multiple entries for topics)
+  // If metadata.ext exists (topics), only remove exact matches
+  // If no metadata.ext (standard cohorts), remove all entries with that name
+  const updatedUserData = currentUserData.filter(el => {
+    if (el.name !== providerName) return true
+    if (metadata.ext && el.ext) {
+      // For topics: only remove if ext matches exactly
+      return JSON.stringify(el.ext) !== JSON.stringify(metadata.ext)
+    }
+    // For non-topics: remove all with same name
+    return metadata.ext !== undefined
+  }).concat(userData, transformedUserData)
+
+  deepSetValue(ortbConfig, 'ortb2.user.data', updatedUserData)
+}
+
+/**
+ * Applies cohorts to user.keywords location
+ * @param {Object} ortbConfig - ORTB2 config object
+ * @param {string} keywordKey - Keyword key (e.g., p_standard)
+ * @param {string[]} cohorts - Cohorts to apply
+ */
+function applyToUserKeywords(ortbConfig, keywordKey, cohorts) {
+  if (cohorts.length === 0) return
+
+  const currentKeywords = deepAccess(ortbConfig, 'ortb2.user.keywords') || ''
+  const existingKeywords = currentKeywords.split(',').map(kv => kv.trim()).filter(Boolean)
+
+  const newKeywords = cohorts.map(id => `${keywordKey}=${id}`)
+
+  const keywords = Array.from(new Set([...existingKeywords, ...newKeywords]))
+    .filter(Boolean)
+    .join(',')
+
+  deepSetValue(ortbConfig, 'ortb2.user.keywords', keywords)
+}
+
+/**
+ * Applies cohorts to user.ext.data location
+ * @param {Object} ortbConfig - ORTB2 config object
+ * @param {string} key - Key name
+ * @param {string[]} cohorts - Cohorts to apply
+ */
+function applyToUserExtData(ortbConfig, key, cohorts) {
+  if (cohorts.length === 0) return
+  deepSetValue(ortbConfig, `ortb2.user.ext.data.${key}`, cohorts)
+}
+
+/**
+ * Applies cohorts to site.ext.permutive location
+ * @param {Object} ortbConfig - ORTB2 config object
+ * @param {string} key - Key name
+ * @param {string[]} cohorts - Cohorts to apply
+ */
+function applyToSiteExtPermutive(ortbConfig, key, cohorts) {
+  if (cohorts.length === 0) return
+  deepSetValue(ortbConfig, `ortb2.site.ext.permutive.${key}`, cohorts)
+}
+
+// ============================================================================
+// SDK CONFIG UTILITIES
+// ============================================================================
+
+/**
+ * Reads and validates SDK-driven configuration from _ppbconf
+ * @return {Array} Array of validated configuration entries
+ */
+function readSdkConfig() {
+  const config = readSegments(SDK_CONFIG_KEY, null)
+  if (!config || !Array.isArray(config)) {
+    return []
+  }
+  return config.filter(entry => validateSdkConfigEntry(entry))
+}
+
+/**
+ * Validates a single SDK config entry
+ * @param {Object} entry - Config entry to validate
+ * @return {boolean} True if valid
+ */
+function validateSdkConfigEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    logger.logWarn('Invalid SDK config entry: not an object', entry)
+    return false
+  }
+
+  if (!Array.isArray(entry.bidders) || entry.bidders.length === 0) {
+    logger.logWarn('Invalid SDK config entry: bidders must be non-empty array', entry)
+    return false
+  }
+
+  if (!Array.isArray(entry.cohorts)) {
+    logger.logWarn('Invalid SDK config entry: cohorts must be array', entry)
+    return false
+  }
+
+  if (!Array.isArray(entry.locations) || entry.locations.length === 0) {
+    logger.logWarn('Invalid SDK config entry: locations must be non-empty array', entry)
+    return false
+  }
+
+  // Validate each location
+  for (const location of entry.locations) {
+    if (!location || typeof location !== 'object') {
+      logger.logWarn('Invalid SDK config location: not an object', location)
+      return false
+    }
+
+    if (!location.path) {
+      logger.logWarn('Invalid SDK config location: missing path', location)
+      return false
+    }
+
+    // Validate path-specific requirements
+    if (location.path === 'user.data') {
+      if (!location.name) {
+        logger.logWarn('Invalid SDK config location: user.data requires name', location)
+        return false
+      }
+    } else if (['user.ext.data', 'user.keywords', 'site.ext.permutive'].includes(location.path)) {
+      if (!location.key) {
+        logger.logWarn(`Invalid SDK config location: ${location.path} requires key`, location)
+        return false
+      }
+    } else {
+      logger.logWarn('Invalid SDK config location: unknown path', location)
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Builds a unique location key for the cohort map
+ * @param {Object} location - Location config object
+ * @return {string} Location key
+ */
+function buildLocationKey(location) {
+  if (location.path === 'user.data') {
+    return `user.data:${location.name}`
+  }
+  return `${location.path}:${location.key}`
+}
+
+// ============================================================================
+// SHARED UTILITIES
+// ============================================================================
+
+/**
+ * Helper to add cohorts to a location in the cohort map
+ * @param {Object} cohortMap - Cohort map
+ * @param {string} bidder - Bidder code
+ * @param {string} locationKey - Location key
+ * @param {string[]} cohorts - Cohorts to add
+ */
+function addToLocation(cohortMap, bidder, locationKey, cohorts) {
+  if (!cohortMap[bidder]) {
+    cohortMap[bidder] = {}
+  }
+  if (!cohortMap[bidder][locationKey]) {
+    cohortMap[bidder][locationKey] = new Set()
+  }
+  cohorts.forEach(cohort => {
+    cohortMap[bidder][locationKey].add(String(cohort))
+  })
+}
+
+/**
  * Gets an array of segment IDs from LocalStorage
  * or return the default value provided.
  * @template A
@@ -422,6 +696,57 @@ function readSegments (key, defaultValue) {
     return defaultValue
   }
 }
+
+/**
+ * Catch and log errors
+ * @param {function} fn - Function to safely evaluate
+ */
+function makeSafe (fn) {
+  try {
+    return fn()
+  } catch (e) {
+    logError(e)
+  }
+}
+
+/**
+ * Check whether ac is enabled for bidder
+ * @param {Object} moduleConfig - Module configuration
+ * @param {string} bidder - Bidder name
+ * @return {boolean}
+ */
+export function isAcEnabled (moduleConfig, bidder) {
+  const acBidders = deepAccess(moduleConfig, 'params.acBidders') || []
+  return acBidders.includes(bidder)
+}
+
+/**
+ * Check whether Permutive is on page
+ * @return {boolean}
+ */
+export function isPermutiveOnPage () {
+  return typeof window.permutive !== 'undefined' && typeof window.permutive.ready === 'function'
+}
+
+/**
+ * Get custom bidder function from module config
+ * @param {Object} moduleConfig - Module configuration
+ * @param {string} bidder - Bidder name
+ * @return {function|null}
+ */
+function getCustomBidderFn (moduleConfig, bidder) {
+  const overwriteFn = deepAccess(moduleConfig, `params.overwrites.${bidder}`)
+
+  if (overwriteFn && isFn(overwriteFn)) {
+    return overwriteFn
+  } else {
+    return null
+  }
+}
+
+// ============================================================================
+// TRANSFORMATION UTILITIES
+// ============================================================================
 
 const unknownIabSegmentId = '_unknown_'
 
@@ -451,27 +776,85 @@ function iabSegmentId(permutiveSegmentId, iabIds) {
   return iabIds[permutiveSegmentId] || unknownIabSegmentId
 }
 
+// ============================================================================
+// CONFIG MANAGEMENT UTILITIES
+// ============================================================================
+
 /**
- * Pull the latest configuration and cohort information and update accordingly.
- * @param {Object} reqBidsConfigObj - Bidder provided config for request
- * @param {Object} moduleConfig - Publisher provided config
+ * Lift params into params object wrapper
+ * @param {Object} params - Parameters
+ * @return {Object}
  */
-export function readAndSetCohorts(reqBidsConfigObj, moduleConfig) {
-  const segmentData = getSegments(deepAccess(moduleConfig, 'params.maxSegs'))
+function liftIntoParams(params) {
+  return isPlainObject(params) ? { params } : {}
+}
 
-  makeSafe(function () {
-    // Legacy route with custom parameters
-    // ACK policy violation, in process of removing
-    setSegments(reqBidsConfigObj, moduleConfig, segmentData)
-  });
+/**
+ * Access the submodules RTD params that are cached to LocalStorage by the Permutive SDK. This lets the RTD submodule
+ * apply publisher defined params set in the Permutive platform, so they may still be applied if the Permutive SDK has
+ * not initialised before this submodule is initialised.
+ */
+function readPermutiveModuleConfigFromCache() {
+  const params = safeJSONParse(storage.getDataFromLocalStorage(PERMUTIVE_SUBMODULE_CONFIG_KEY))
+  cachedPermutiveModuleConfig = liftIntoParams(params)
+  return cachedPermutiveModuleConfig
+}
 
-  makeSafe(function () {
-    // Route for bidders supporting ORTB2
-    setBidderRtb(reqBidsConfigObj.ortb2Fragments?.bidder, moduleConfig, segmentData)
+/**
+ * Access the submodules RTD params attached to the Permutive SDK.
+ *
+ * @return The Permutive config available by the Permutive SDK or null if the operation errors.
+ */
+function getParamsFromPermutive() {
+  try {
+    return liftIntoParams(window.permutive.addons.prebid.getPermutiveRtdConfig())
+  } catch (e) {
+    return null
+  }
+}
+
+// ============================================================================
+// LEGACY FUNCTIONS
+// ============================================================================
+
+/**
+ * Set segments on bid request object (legacy custom parameters route)
+ * @param {Object} reqBidsConfigObj - Bid request object
+ * @param {Object} moduleConfig - Module configuration
+ * @param {Object} segmentData - Segment object
+ */
+function setSegments (reqBidsConfigObj, moduleConfig, segmentData) {
+  const adUnits = (reqBidsConfigObj && reqBidsConfigObj.adUnits) || getGlobal().adUnits
+  const utils = { deepSetValue, deepAccess, isFn, mergeDeep }
+  const aliasMap = {
+    appnexusAst: 'appnexus'
+  }
+
+  if (!adUnits) {
+    return
+  }
+
+  adUnits.forEach(adUnit => {
+    adUnit.bids.forEach(bid => {
+      let { bidder } = bid
+      if (typeof aliasMap[bidder] !== 'undefined') {
+        bidder = aliasMap[bidder]
+      }
+      const acEnabled = isAcEnabled(moduleConfig, bidder)
+      const customFn = getCustomBidderFn(moduleConfig, bidder)
+
+      if (customFn) {
+        // For backwards compatibility we pass an identity function to any custom bidder function set by a publisher
+        const bidIdentity = (bid) => bid
+        customFn(bid, segmentData, acEnabled, utils, bidIdentity)
+      }
+    })
   })
 }
 
-let permutiveSDKInRealTime = false
+// ============================================================================
+// MODULE REGISTRATION
+// ============================================================================
 
 /** @type {RtdSubmodule} */
 export const permutiveSubmodule = {

--- a/modules/permutiveRtdProvider.md
+++ b/modules/permutiveRtdProvider.md
@@ -46,6 +46,7 @@ as well as enabling settings for specific use cases mentioned above (e.g. acbidd
 | waitForIt              | Boolean              | Should be `true` if there's an `auctionDelay` defined (optional)                              | `false`            |
 | params                 | Object               |                                                                                               | -                  |
 | params.acBidders       | String[]             | An array of bidder codes to share cohorts with in certain versions of Prebid, see below       | `[]`               |
+| params.ccBidders       | String[]             | An array of bidder codes to receive custom cohorts, see Custom Cohorts section below          | `[]`               |
 | params.maxSegs         | Integer              | Maximum number of cohorts to be included in either the `permutive` or `p_standard` key-value. | `500`              |
 
 #### Context
@@ -100,17 +101,30 @@ For Equativ: Please ensure you are using Prebid.js 7.26 (or later)
 
 #### Custom Cohorts
 
-The Permutive RTD module also supports passing any of the **Custom** Cohorts created in the dashboard to some SSP partners for targeting
-e.g. setting up publisher deals. For these activations, cohort IDs are set in bidder-specific locations per ad unit (custom parameters).
+The Permutive RTD module supports passing **Custom Cohorts** created in the dashboard to specified bidders for targeting (e.g., setting up publisher deals).
 
-Currently, bidders with known support for custom cohort targeting are:
+To enable custom cohorts, add bidder codes to the `ccBidders` parameter:
 
-- Xandr
-- Magnite
+```javascript
+pbjs.setConfig({
+  realTimeData: {
+    dataProviders: [{
+      name: 'permutive',
+      params: {
+        ccBidders: ['appnexus', 'rubicon', 'ozone']
+      }
+    }]
+  }
+})
+```
 
-When enabling the respective Activation for a cohort in Permutive, this module will automatically attach that cohort ID to the bid request.
-There is no need to enable individual bidders in the module configuration, it will automatically reflect which SSP integrations you have enabled in your Permutive dashboard.
-Permutive cohorts will be sent in the permutive key-value.
+**Note:** The following bidders automatically receive custom cohorts for backwards compatibility, even if not included in `ccBidders`:
+- Index Exchange (`ix`)
+- Rubicon/Magnite (`rubicon`)
+- AppNexus/Xandr (`appnexus`)
+- Google Ad Manager (`gam`)
+
+Custom cohorts are read from the `_pprebid` local storage key (set by the Permutive SDK) and are sent to all target bidders in the `permutive` key-value.
 
 
 ### _Enabling Advertiser Cohorts_

--- a/modules/permutiveRtdProvider.md
+++ b/modules/permutiveRtdProvider.md
@@ -40,8 +40,7 @@ pbjs.setConfig({
       name: 'permutive',
       waitForIt: true, // should be true if there's an auctionDelay
       params: {
-        acBidders: ['appnexus', 'rubicon'],
-        ccBidders: ['ozone']
+        acBidders: ['appnexus', 'rubicon']
       }
     }]
   }
@@ -56,8 +55,72 @@ pbjs.setConfig({
 | waitForIt              | Boolean              | Should be `true` if there's an `auctionDelay` defined                                         | `false`            |
 | params                 | Object               | Module configuration parameters                                                               | -                  |
 | params.acBidders       | String[]             | Bidder codes to receive Standard Cohorts and DCR Cohorts (see Standard Cohorts section)      | `[]`               |
-| params.ccBidders       | String[]             | Bidder codes to receive Custom Cohorts (see Custom Cohorts section)                          | `[]`               |
 | params.maxSegs         | Integer              | Maximum number of cohorts per cohort type                                                     | `500`              |
+
+## SDK-Driven Configuration
+
+The Permutive RTD module uses an SDK-driven configuration approach that allows the Permutive SDK to dynamically specify which cohorts should be sent to which bidders and where in the ORTB2 structure they should be placed. This is the recommended approach as it enables flexible cohort distribution without requiring Prebid configuration changes.
+
+### How It Works
+
+The Permutive SDK writes cohort distribution rules to the `_ppbconf` local storage key. The RTD module reads this configuration and applies it automatically alongside any legacy configuration (`acBidders`, Custom Cohorts for specific bidders, etc.). Both modes run simultaneously - cohorts from both sources are merged and deduplicated before being sent to bidders.
+
+### Configuration Structure
+
+The `_ppbconf` key contains an array of cohort distribution rules:
+
+```javascript
+[
+  {
+    "bidders": ["appnexus", "rubicon"],
+    "cohorts": ["cohort1", "cohort2", "cohort3"],
+    "locations": [
+      {
+        "path": "user.data",
+        "name": "permutive.com"
+      },
+      {
+        "path": "user.keywords",
+        "key": "p_standard"
+      }
+    ]
+  }
+]
+```
+
+Each rule specifies:
+- **bidders**: Array of bidder codes that should receive these cohorts
+- **cohorts**: Array of cohort IDs to send
+- **locations**: Array of ORTB2 locations where cohorts should be placed
+
+### Supported Locations
+
+| Path | Required Fields | Description | Example |
+|------|----------------|-------------|---------|
+| `user.data` | `name` | User data provider | `{"path": "user.data", "name": "permutive.com"}` |
+| `user.keywords` | `key` | Keywords with key prefix | `{"path": "user.keywords", "key": "p_standard"}` |
+| `user.ext.data` | `key` | User extended data | `{"path": "user.ext.data", "key": "p_standard"}` |
+| `site.ext.permutive` | `key` | Site extended data | `{"path": "site.ext.permutive", "key": "p_standard"}` |
+
+### Privacy Sandbox Topics
+
+For Privacy Sandbox Topics, include the `ext` field with the taxonomy version:
+
+```javascript
+{
+  "bidders": ["appnexus"],
+  "cohorts": ["1", "2", "3"],
+  "locations": [
+    {
+      "path": "user.data",
+      "name": "permutive.com",
+      "ext": {
+        "segtax": 600
+      }
+    }
+  ]
+}
+```
 
 ## GDPR and TCF Configuration
 
@@ -113,30 +176,19 @@ Standard Cohorts are sent to bidders in the `p_standard` keyword and as `ortb2.u
 
 Custom Cohorts are publisher-defined audience segments created in the Permutive dashboard, typically used for direct deals and private marketplace (PMP) setups.
 
-To enable Custom Cohorts for specific bidders, add their bidder codes to the `ccBidders` parameter:
-
-```javascript
-pbjs.setConfig({
-  realTimeData: {
-    dataProviders: [{
-      name: 'permutive',
-      params: {
-        ccBidders: ['appnexus', 'rubicon', 'ozone']
-      }
-    }]
-  }
-})
-```
-
 **Legacy Bidder Support:**
 
-The following bidders automatically receive Custom Cohorts for backwards compatibility, even if not included in `ccBidders`:
+The following bidders automatically receive Custom Cohorts for backwards compatibility:
 - Index Exchange (`ix`)
 - Rubicon/Magnite (`rubicon`)
 - AppNexus/Xandr (`appnexus`)
 - Google Ad Manager (`gam`)
 
-Custom Cohorts are read from the `_pprebid` local storage key (set by the Permutive SDK) and sent to target bidders in the `permutive` keyword and as `ortb2.user.data` with provider name `permutive`.
+Custom Cohorts are read from legacy local storage keys (e.g., `_papns`, `_prubicons`, `_pindexs`, `_pdfps`) set by the Permutive SDK and sent to these bidders in the `permutive` keyword and as `ortb2.user.data` with provider name `permutive`.
+
+**Extending Custom Cohorts to Additional Bidders:**
+
+To send Custom Cohorts to additional bidders beyond the four legacy bidders, use the SDK-Driven Configuration mode (see SDK-Driven Configuration section above). The Permutive SDK can specify custom cohort distribution rules via the `_ppbconf` local storage key.
 
 ### Advertiser Cohorts
 

--- a/modules/permutiveRtdProvider.md
+++ b/modules/permutiveRtdProvider.md
@@ -1,10 +1,25 @@
-## Prebid Config for Permutive RTD Module
+# Permutive Real-time Data Submodule
 
-This module reads cohorts from Permutive and attaches them as targeting keys to bid requests.
+## Overview
 
-### _Permutive Real-time Data Submodule_
+    Module Name: Permutive Rtd Provider
+    Module Type: Rtd Provider
+    Maintainer: support@permutive.com
 
-#### Usage
+## Description
+
+The Permutive real-time data module enables publishers to enrich bid requests with Permutive audience segments and targeting data. The module reads cohort data from local storage (set by the Permutive SDK) and attaches it to bid requests as first-party data following OpenRTB 2.x conventions.
+
+Supported cohort types include:
+- **Standard Cohorts**: IAB-compliant audience segments (segment IDs ≥ 1000000)
+- **Custom Cohorts**: Publisher-defined audiences created in the Permutive dashboard
+- **DCR Cohorts**: Data Clean Room cohorts for privacy-safe audience activation
+- **Curation Cohorts**: SSP-specific curation signals for supply-side optimization
+
+## Usage
+
+### Build
+
 Compile the Permutive RTD module into your Prebid build:
 
 ```
@@ -13,97 +28,92 @@ gulp build --modules=rtdModule,permutiveRtdProvider
 
 > Note that the global RTD module, `rtdModule`, is a prerequisite of the Permutive RTD module.
 
-You then need to enable the Permutive RTD in your Prebid configuration. Below is an example of the format:
+### Configuration
+
+Enable the Permutive RTD module in your Prebid configuration:
 
 ```javascript
 pbjs.setConfig({
-  ...,
   realTimeData: {
     auctionDelay: 50, // optional auction delay
     dataProviders: [{
       name: 'permutive',
-      waitForIt: true, // should be true if there's an `auctionDelay`
+      waitForIt: true, // should be true if there's an auctionDelay
       params: {
-        acBidders: ['appnexus']
+        acBidders: ['appnexus', 'rubicon'],
+        ccBidders: ['ozone']
       }
     }]
-  },
-  ...
+  }
 })
 ```
 
-#### Parameters
+### Parameters
 
-The parameters below provide configurability for general behaviours of the RTD submodule,
-as well as enabling settings for specific use cases mentioned above (e.g. acbidders).
-
-## Parameters
-
-{: .table .table-bordered .table-striped }
 | Name                   | Type                 | Description                                                                                   | Default            |
 | ---------------------- | -------------------- | --------------------------------------------------------------------------------------------- | ------------------ |
-| name                   | String               | This should always be `permutive`                                                             | -                  |
-| waitForIt              | Boolean              | Should be `true` if there's an `auctionDelay` defined (optional)                              | `false`            |
-| params                 | Object               |                                                                                               | -                  |
-| params.acBidders       | String[]             | An array of bidder codes to share cohorts with in certain versions of Prebid, see below       | `[]`               |
-| params.ccBidders       | String[]             | An array of bidder codes to receive custom cohorts, see Custom Cohorts section below          | `[]`               |
-| params.maxSegs         | Integer              | Maximum number of cohorts to be included in either the `permutive` or `p_standard` key-value. | `500`              |
+| name                   | String               | Real-time data module name (always `permutive`)                                               | -                  |
+| waitForIt              | Boolean              | Should be `true` if there's an `auctionDelay` defined                                         | `false`            |
+| params                 | Object               | Module configuration parameters                                                               | -                  |
+| params.acBidders       | String[]             | Bidder codes to receive Standard Cohorts and DCR Cohorts (see Standard Cohorts section)      | `[]`               |
+| params.ccBidders       | String[]             | Bidder codes to receive Custom Cohorts (see Custom Cohorts section)                          | `[]`               |
+| params.maxSegs         | Integer              | Maximum number of cohorts per cohort type                                                     | `500`              |
 
-#### Context
+## GDPR and TCF Configuration
 
-While Permutive is listed as a TCF vendor (ID: 361), Permutive does not obtain consent directly from the TCF. As we act as a processor on behalf of our publishers consent is given to the Permutive SDK by the publisher, not by the [GDPR Consent Management Module](https://prebid-docs.atre.net/dev-docs/modules/consentManagement.html).
+While Permutive is listed as a TCF vendor (ID: 361), Permutive does not obtain consent directly from the TCF. As a data processor, consent is managed by the Permutive SDK on behalf of publishers, not by Prebid's [GDPR Consent Management Module](https://docs.prebid.org/dev-docs/modules/consentManagement.html).
 
-This means that if GDPR enforcement is configured within the Permutive SDK _and_ the user consent isn’t given for Permutive to fire, no cohorts will populate.
+If GDPR enforcement is configured within the Permutive SDK and user consent is not granted, no cohorts will be passed to bidders.
 
-If you are also using the [TCF Control Module](https://docs.prebid.org/dev-docs/modules/tcfControl.html), in order to prevent Permutive from being blocked, it needs to be labeled within the Vendor Exceptions.
+### TCF Control Module Configuration
 
-#### Instructions
+If you are using the [TCF Control Module](https://docs.prebid.org/dev-docs/modules/tcfControl.html), Permutive must be added as a vendor exception to prevent it from being blocked:
 
-1. Publisher enables rules within Prebid.js configuration. 
-2. Label Permutive as an exception, as shown below.
 ```javascript
-[
-  {
-    purpose: 'storage',
-    enforcePurpose: true,
-    enforceVendor: true,
-    vendorExceptions: ["permutive"]
-  },
-  {
-    purpose: 'basicAds',
-    enforcePurpose: true,
-    enforceVendor: true,
-    vendorExceptions: []
+pbjs.setConfig({
+  consentManagement: {
+    gdpr: {
+      rules: [{
+        purpose: 'storage',
+        enforcePurpose: true,
+        enforceVendor: true,
+        vendorExceptions: ['permutive']
+      }, {
+        purpose: 'basicAds',
+        enforcePurpose: true,
+        enforceVendor: true,
+        vendorExceptions: []
+      }]
+    }
   }
-]
+})
 ```
 
-Before making any updates to this configuration, please ensure that this approach aligns with internal policies and current regulations regarding consent.
+Before implementing this configuration, ensure it aligns with your organization's privacy policies and regulatory requirements.
 
-## Cohort Activation with Permutive RTD Module
+## Cohort Configuration
 
-**Note**: Publishers must be enabled on the above Permutive RTD Submodule to enable Standard Cohorts.
+### Standard Cohorts
 
-### _Enabling Publisher Cohorts_
+Standard Cohorts are IAB-compliant audience segments that can be shared with demand partners. The module automatically includes DCR Cohorts (Data Clean Room) alongside Standard Cohorts when sharing with bidders.
 
-#### Standard Cohorts
+**Prebid.js Version Requirements:**
+- **Version 7.29.0+**: Standard Cohorts are shared via OpenRTB 2.x first-party data. Configure eligible bidders in the Permutive dashboard (see Managing acBidders below).
+- **Version 7.13.0 - 7.28.x**: Use `params.acBidders` to specify which bidders should receive Standard Cohorts.
+- **Version < 7.13.0**: Limited support. Upgrade recommended.
 
-The Permutive RTD module sets Standard Cohort IDs as bidder-specific ortb2.user.data first-party data, following the Prebid ortb2 convention. Cohorts will be sent in the `p_standard` key-value.
+**Bidder-Specific Requirements:**
+- **PubMatic or OpenX**: Prebid.js 7.13+
+- **Xandr**: Prebid.js 7.29+
+- **Equativ**: Prebid.js 7.26+
 
-For Prebid versions below 7.29.0, populate the acbidders config in the Permutive RTD with an array of bidder codes with whom you wish to share Standard Cohorts with. You also need to permission the bidders by communicating the bidder list to the Permutive team at strategicpartnershipops@permutive.com.
+Standard Cohorts are sent to bidders in the `p_standard` keyword and as `ortb2.user.data` with provider name `permutive.com`. Curation Cohorts from SSPs are sent in the `p_standard_aud` keyword when applicable.
 
-For Prebid versions 7.29.0 and above, do not populate bidder codes in acbidders for the purpose of sharing Standard Cohorts (Note: there may be other business needs that require you to populate acbidders for Prebid versions 7.29.0+, see Advertiser Cohorts below). To share Standard Cohorts with bidders in Prebid versions 7.29.0 and above, communicate the bidder list to the Permutive team at strategicpartnershipops@permutive.com.
+### Custom Cohorts
 
-#### _Bidder Specific Requirements for Standard Cohorts_
-For PubMatic or OpenX: Please ensure you are using Prebid.js 7.13 (or later)
-For Xandr: Please ensure you are using Prebid.js 7.29 (or later)
-For Equativ: Please ensure you are using Prebid.js 7.26 (or later)
+Custom Cohorts are publisher-defined audience segments created in the Permutive dashboard, typically used for direct deals and private marketplace (PMP) setups.
 
-#### Custom Cohorts
-
-The Permutive RTD module supports passing **Custom Cohorts** created in the dashboard to specified bidders for targeting (e.g., setting up publisher deals).
-
-To enable custom cohorts, add bidder codes to the `ccBidders` parameter:
+To enable Custom Cohorts for specific bidders, add their bidder codes to the `ccBidders` parameter:
 
 ```javascript
 pbjs.setConfig({
@@ -118,51 +128,63 @@ pbjs.setConfig({
 })
 ```
 
-**Note:** The following bidders automatically receive custom cohorts for backwards compatibility, even if not included in `ccBidders`:
+**Legacy Bidder Support:**
+
+The following bidders automatically receive Custom Cohorts for backwards compatibility, even if not included in `ccBidders`:
 - Index Exchange (`ix`)
 - Rubicon/Magnite (`rubicon`)
 - AppNexus/Xandr (`appnexus`)
 - Google Ad Manager (`gam`)
 
-Custom cohorts are read from the `_pprebid` local storage key (set by the Permutive SDK) and are sent to all target bidders in the `permutive` key-value.
+Custom Cohorts are read from the `_pprebid` local storage key (set by the Permutive SDK) and sent to target bidders in the `permutive` keyword and as `ortb2.user.data` with provider name `permutive`.
 
+### Advertiser Cohorts
 
-### _Enabling Advertiser Cohorts_
+If you are using Permutive's Advertiser product to share cohorts with demand partners, add the relevant bidder codes to `params.acBidders` to enable Advertiser Cohort sharing.
 
-If you are connecting to an Advertiser seat within Permutive to share Advertiser Cohorts,  populate the acbidders config in the Permutive RTD with an array of bidder codes with whom you wish to share Advertiser Cohorts with.
+### Managing acBidders
 
-### _Managing acbidders_
+For Prebid.js version 7.13.0 and above, bidders can be managed directly in the Permutive Dashboard.
 
-If your business needs require you to populate acbidders with bidder codes based on the criteria above, there are **two** ways to manage it.
+#### Dashboard Configuration
 
-#### Option 1 - Automated
+1. **Enable Prebid Integration**: Navigate to the integrations page in your Permutive dashboard settings and enable the Prebid integration.
 
-If you are using Prebid.js v7.13.0+, bidders may be added to or removed from the acbidders config directly within the Permutive Dashboard.
+   > **Note on Revenue Insights:** The Prebid integration includes a Revenue Insights feature, which is optional and not required for cohort activation. See the [Revenue Insights documentation](https://support.permutive.com/hc/en-us/articles/360019044079-Revenue-Insights) for more details.
 
-**Permutive can do this on your behalf**. Simply contact your Permutive CSM with strategicpartnershipops@permutive.com on cc,
-indicating which bidders you would like added.
+2. **Configure Bidders**: In the "Data Provider config" section, enter valid bidder codes to enable Standard Cohorts, DCR Cohorts, or Advertiser Cohorts for specific partners. Refer to the [Prebid bidder codes list](https://docs.prebid.org/dev-docs/bidders.html) for valid values.
 
-Or, a publisher may do this themselves within the Permutive Dashboard using the below instructions.
+3. **Manual Override**: Bidders configured via the dashboard will automatically populate `params.acBidders`. If you have manually defined bidders in your Prebid configuration, dashboard settings will not override them.
 
-##### Create Integration
+#### Manual Configuration
 
-In order to manage acbidders via the Permutive dashboard, it is necessary to first enable the Prebid integration via the integrations page (settings).
+Alternatively, you can manually define bidders in your Prebid configuration:
 
-**Note on Revenue Insights:** The prebid integration includes a feature for revenue insights,
-which is not required for the purpose of updating acbidders config.
-Please see [this document](https://support.permutive.com/hc/en-us/articles/360019044079-Revenue-Insights) for more information about revenue insights.
+```javascript
+pbjs.setConfig({
+  realTimeData: {
+    dataProviders: [{
+      name: 'permutive',
+      params: {
+        acBidders: ['appnexus', 'rubicon', 'pubmatic']
+      }
+    }]
+  }
+})
+```
 
-##### Update acbidders
+**Note:** Manually configured bidders must be removed manually if no longer needed, as dashboard settings will not override them.
 
-The input for the “Data Provider config” is a multi-input free text. A valid “bidder code” needs to be entered in order to enable Standard or Advertiser Cohorts to be passed to the desired partner. The [prebid Bidders page](https://docs.prebid.org/dev-docs/bidders.html) contains instructions and a link to a list of possible bidder codes.
+## Testing
 
-Bidders can be added or removed from acbidders using this feature, however, this will not impact any bidders that have been applied using the manual method below.
+To view an example of the Permutive RTD module:
 
-#### Option 2 - Manual
+```
+gulp serve --modules=rtdModule,permutiveRtdProvider,appnexusBidAdapter
+```
 
-As a secondary option, bidders may be added manually.
+Then navigate to:
 
-To do so, define which bidders should receive Standard or Advertiser Cohorts by
-including the _bidder code_ of any bidder in the `acBidders` array.
-
-**Note:** If you ever need to remove a manually-added bidder, the bidder will also need to be removed manually.
+```
+http://localhost:9999/integrationExamples/gpt/permutiveRtdProvider_example.html
+```

--- a/test/spec/modules/permutiveCombined_spec.js
+++ b/test/spec/modules/permutiveCombined_spec.js
@@ -393,14 +393,14 @@ describe('permutiveRtdProvider', function () {
 
       acBidders.forEach(bidder => {
         const customCohortsData = segmentsData.customCohorts || []
+        const isSspBidder = segmentsData.ssp.ssps.includes(bidder)
+
         const keywordGroups = {
           [PERMUTIVE_STANDARD_KEYWORD]: segmentsData.ac,
-          [PERMUTIVE_STANDARD_AUD_KEYWORD]: segmentsData.ssp.cohorts,
+          [PERMUTIVE_STANDARD_AUD_KEYWORD]: isSspBidder ? segmentsData.ssp.cohorts : [],
           [PERMUTIVE_CUSTOM_COHORTS_KEYWORD]: customCohortsData
         }
 
-        // Transform groups of key-values into a single array of strings
-        // i.e { permutive: ['1', '2'], p_standard: ['3', '4'] } => ['permutive=1', 'permutive=2', 'p_standard=3',' p_standard=4']
         const transformedKeywordGroups = Object.entries(keywordGroups)
           .flatMap(([keyword, ids]) => ids.map(id => `${keyword}=${id}`))
 

--- a/test/spec/modules/permutiveCombined_spec.js
+++ b/test/spec/modules/permutiveCombined_spec.js
@@ -459,7 +459,6 @@ describe('permutiveRtdProvider', function () {
     it('should merge ortb2 correctly for ac and ssps', function () {
       const customTargetingData = {
         ...getTargetingData(),
-        '_ppam': [],
         '_psegs': [],
         '_pcrprs': ['abc', 'def', 'xyz'],
         '_pssps': {
@@ -529,7 +528,6 @@ describe('permutiveRtdProvider', function () {
           _prubicons: [],
           _papns: [],
           _psegs: [],
-          _ppam: [],
           _pcrprs: [],
           _pindexs: [],
           _pssps: { ssps: [], cohorts: [] },
@@ -782,7 +780,7 @@ function transformedTargeting (data = getTargetingData()) {
   })()
 
   return {
-    ac: [...data._pcrprs, ...data._ppam, ...data._psegs.filter(seg => seg >= 1000000)].map(String),
+    ac: [...data._pcrprs, ...data._psegs.filter(seg => seg >= 1000000)].map(String),
     appnexus: data._papns.map(String),
     ix: data._pindexs.map(String),
     rubicon: data._prubicons.map(String),
@@ -801,7 +799,6 @@ function getTargetingData () {
     _prubicons: ['rubicon1', 'rubicon2'],
     _papns: ['appnexus1', 'appnexus2'],
     _psegs: ['1234', '1000001', '1000002'],
-    _ppam: ['ppam1', 'ppam2'],
     _pindexs: ['pindex1', 'pindex2'],
     _pcrprs: ['pcrprs1', 'pcrprs2', 'dup'],
     _pssps: { ssps: ['xyz', 'abc', 'dup'], cohorts: ['123', 'abc'] },

--- a/test/spec/modules/permutiveCombined_spec.js
+++ b/test/spec/modules/permutiveCombined_spec.js
@@ -48,7 +48,6 @@ describe('permutiveRtdProvider', function () {
       params: {
         maxSegs: 500,
         acBidders: [],
-        ccBidders: [],
         overwrites: {},
       },
     })
@@ -201,7 +200,7 @@ describe('permutiveRtdProvider', function () {
       setBidderRtb(bidderConfig, moduleConfig, segmentsData)
 
       acBidders.forEach(bidder => {
-        const customCohorts = segmentsData.customCohorts || []
+        const customCohorts = segmentsData[bidder] || []
         expect(bidderConfig[bidder].user.data).to.deep.include.members([
           {
             name: 'permutive.com',
@@ -267,20 +266,30 @@ describe('permutiveRtdProvider', function () {
 
       setBidderRtb(bidderConfig, moduleConfig, segmentsData)
 
+      const legacyCcBidders = ['ix', 'rubicon', 'appnexus', 'gam']
+
       acBidders.forEach(bidder => {
-        const customCohorts = segmentsData.customCohorts || []
+        const customCohorts = segmentsData[bidder] || []
+        const isLegacyCcBidder = legacyCcBidders.includes(bidder)
 
         expect(bidderConfig[bidder].user.data).to.not.deep.include.members([...sampleOrtbConfig.user.data])
-        expect(bidderConfig[bidder].user.data).to.deep.include.members([
-          {
-            name: reservedPermutiveCustomCohortName,
-            segment: customCohorts.map(id => ({ id })),
-          },
+
+        const expectedUserData = [
           {
             name: reservedPermutiveStandardName,
             segment: segmentsData.ac.map(id => ({ id })),
           },
-        ])
+        ]
+
+        // Only legacy bidders get custom cohorts
+        if (isLegacyCcBidder && customCohorts.length > 0) {
+          expectedUserData.push({
+            name: reservedPermutiveCustomCohortName,
+            segment: customCohorts.map(id => ({ id })),
+          })
+        }
+
+        expect(bidderConfig[bidder].user.data).to.deep.include.members(expectedUserData)
       })
     })
 
@@ -391,8 +400,10 @@ describe('permutiveRtdProvider', function () {
 
       setBidderRtb(bidderConfig, moduleConfig, segmentsData)
 
+      const legacyCcBidders = ['ix', 'rubicon', 'appnexus', 'gam']
+
       acBidders.forEach(bidder => {
-        const customCohortsData = segmentsData.customCohorts || []
+        const customCohortsData = legacyCcBidders.includes(bidder) ? (segmentsData[bidder] || []) : []
         const isSspBidder = segmentsData.ssp.ssps.includes(bidder)
 
         const keywordGroups = {
@@ -443,8 +454,11 @@ describe('permutiveRtdProvider', function () {
 
       setBidderRtb(bidderConfig, moduleConfig, segmentsData)
 
+      const legacyCcBidders = ['ix', 'rubicon', 'appnexus', 'gam']
+
       acBidders.forEach(bidder => {
-        const customCohortsData = segmentsData.customCohorts || []
+        // Only legacy bidders get custom cohorts
+        const customCohortsData = legacyCcBidders.includes(bidder) ? (segmentsData[bidder] || []) : []
 
         const expectedKeywords = [
           ...existingKeywords,
@@ -538,7 +552,10 @@ describe('permutiveRtdProvider', function () {
         setBidderRtb(bidderConfig, moduleConfig, segmentsData)
 
         moduleConfig.params.acBidders.forEach(bidder => {
-          expect(bidderConfig[bidder].user).to.not.have.property('ext')
+          // When there are no cohorts, user.ext should not be created
+          if (bidderConfig[bidder] && bidderConfig[bidder].user) {
+            expect(bidderConfig[bidder].user).to.not.have.property('ext')
+          }
         })
       })
 
@@ -551,14 +568,18 @@ describe('permutiveRtdProvider', function () {
 
         setBidderRtb(bidderConfig, moduleConfig, segmentsData)
 
+        const legacyCcBidders = ['ix', 'rubicon', 'appnexus', 'gam']
+
         moduleConfig.params.acBidders.forEach(bidder => {
           const userExtData = {
             // Default targeting
             p_standard: segmentsData.ac,
           }
 
-          const customCohorts = segmentsData.customCohorts || []
-          if (customCohorts.length > 0) {
+          // Only legacy bidders get custom cohorts
+          const isLegacyCcBidder = legacyCcBidders.includes(bidder)
+          const customCohorts = segmentsData[bidder] || []
+          if (isLegacyCcBidder && customCohorts.length > 0) {
             deepSetValue(userExtData, 'permutive', customCohorts)
           }
 
@@ -573,8 +594,11 @@ describe('permutiveRtdProvider', function () {
         const bidderConfig = {}
 
         const segmentsData = transformedTargeting()
-        // Remove custom cohorts by setting to empty array
-        segmentsData.customCohorts = []
+        // Remove custom cohorts by setting bidder-specific arrays to empty
+        segmentsData.appnexus = []
+        segmentsData.rubicon = []
+        segmentsData.ix = []
+        segmentsData.gam = []
 
         setBidderRtb(bidderConfig, moduleConfig, segmentsData)
 
@@ -596,9 +620,13 @@ describe('permutiveRtdProvider', function () {
 
         setBidderRtb(bidderConfig, moduleConfig, segmentsData)
 
+        const legacyCcBidders = ['ix', 'rubicon', 'appnexus', 'gam']
+
         moduleConfig.params.acBidders.forEach(bidder => {
-          const customCohorts = segmentsData.customCohorts || []
-          if (customCohorts.length > 0) {
+          const customCohorts = segmentsData[bidder] || []
+          const isLegacyCcBidder = legacyCcBidders.includes(bidder)
+
+          if (isLegacyCcBidder && customCohorts.length > 0) {
             expect(bidderConfig[bidder].user.ext.data).to.deep
               .eq({ permutive: customCohorts })
           } else {
@@ -644,7 +672,7 @@ describe('permutiveRtdProvider', function () {
 
       const segments = getSegments(200)
 
-      expect(segments.customCohorts).to.deep.equal(['1', '2', '3'])
+      expect(segments.rubicon).to.deep.equal(['1', '2', '3'])
       expect(segments.ssp.ssps).to.deep.equal(['foo', 'bar'])
       expect(segments.ssp.cohorts).to.deep.equal(['4', '5', '6'])
     })
@@ -661,7 +689,7 @@ describe('permutiveRtdProvider', function () {
 
       const segments = getSegments(200)
 
-      expect(segments.customCohorts).to.deep.equal([])
+      expect(segments.rubicon).to.deep.equal([])
       expect(segments.ssp.ssps).to.deep.equal([])
       expect(segments.ssp.cohorts).to.deep.equal([])
     })
@@ -778,7 +806,6 @@ function getConfig () {
     waitForIt: true,
     params: {
       acBidders: ['appnexus', 'rubicon', 'ozone', 'trustx', 'ix'],
-      ccBidders: ['appnexus', 'rubicon', 'ozone', 'trustx', 'ix'],  // Same as acBidders so tests receive custom cohorts
       maxSegs: 500
     }
   }
@@ -793,19 +820,12 @@ function transformedTargeting (data = getTargetingData()) {
     return topics
   })()
 
-  // Merge all custom cohorts (from _pprebid + legacy keys)
-  const pprebid = data._pprebid || []
-  const customCohorts = [...new Set([
-    ...pprebid,
-    ...data._papns,
-    ...data._prubicons,
-    ...data._pindexs,
-    ...data._pdfps
-  ])].map(String)
-
   return {
     ac: [...data._pcrprs, ...data._psegs.filter(seg => seg >= 1000000)].map(String),
-    customCohorts: customCohorts,
+    appnexus: data._papns.map(String),
+    ix: data._pindexs.map(String),
+    rubicon: data._prubicons.map(String),
+    gam: data._pdfps.map(String),
     ssp: {
       ssps: data._pssps.ssps.map(String),
       cohorts: data._pssps.cohorts.map(String)


### PR DESCRIPTION
# Permutive RTD Provider: SDK-Driven Configuration

  ## Summary

  Implements SDK-driven cohort distribution, moving business logic out of the RTD module. This cleaner interface between Permutive SDK and the RTD module enables dynamic cohort distribution without Prebid configuration changes.

  Existing interfaces are still supported, and can be migrated to the new interface incrementally. 

  ## Key Changes

  ### 1. SDK-Driven Configuration 

  The Permutive SDK can now specify cohort distribution via the `_ppbconf` localStorage key, for example:

  ```json
  [
    {
      "bidders": ["appnexus", "rubicon"],
      "cohorts": ["cohort1", "cohort2", "cohort3"],
      "locations": [
        {
          "path": "user.data",
          "name": "permutive.com"
        },
        {
          "path": "user.keywords",
          "key": "p_standard"
        }
      ]
    },
    {
      "bidders": ["rubicon", "ozone"],
      "cohorts": ["custom_cohort_1", "custom_cohort_2"],
      "locations": [
        {
          "path": "user.data",
          "name": "permutive"
        }
      ]
    }
    {
      "bidders": ["ozone"],
      "cohorts": ["topic1", "topic2"],
      "locations": [
        {
          "path": "user.data",
          "name": "permutive",
          "ext": {
            "segtax": 600
          }
        }
      ]
    }
  ]
```

  ### 2.  Dual-Mode Operation

  - SDK-driven and legacy configurations run simultaneously
  - Cohorts are merged and deduplicated at the cohort level
  - Single maxSegs limit applied after merging
  - Maintains full backwards compatibility

  ### 3. Backwards Compatibility

  - All legacy localStorage keys still supported
  - All existing configurations work unchanged